### PR TITLE
Feature: Speed up event dispatch

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,28 +5,35 @@ let portfinder = require('portfinder');
 let ip = require('ip');
 let util = require('util');
 let events = require('events');
-let xmlResponseParser = require('parsexmlresponse');
+let xml = require('xml2js');
 
 let httpServerPort;
-let httpSubscriptionResponseServer;
 
 let subscriptions = new Map();
 
 portfinder.getPort(function (err, availablePort) {
-    httpSubscriptionResponseServer = http.createServer();
-    httpServerPort = availablePort;
-    httpSubscriptionResponseServer.listen(httpServerPort, () => {
-        httpSubscriptionResponseServer.on('request', (req) => {
-            let sid = req.headers.sid;
-            let handle = xmlResponseParser((err, data) => {
-                let emitter = subscriptions.get(sid);
-                if (emitter) {
-                    emitter.emit('message', { sid: sid, body: data });
-                }
-            });
-            handle(req);
-        });
-    });
+    httpServerPort = availablePort
+    http.createServer(function (req, res) {
+      var buffer = ''
+      req.on('data', function (d) {
+        buffer += d
+      })
+
+      req.on('end', function () {
+        req.body = buffer
+
+        let sid = req.headers.sid;
+
+        xml.parseString(req.body, (err, result) => {
+            let emitter = subscriptions.get(sid);
+            if (emitter) {
+                emitter.emit('message', { sid: sid, body: result });
+            }
+        })
+
+        res.end()
+      })
+    }).listen(httpServerPort)
 });
 
 function Subscription(host, port, eventSub, requestedTimeoutSeconds) {

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ portfinder.getPort(function (err, availablePort) {
     httpSubscriptionResponseServer = http.createServer();
     httpServerPort = availablePort;
     httpSubscriptionResponseServer.listen(httpServerPort, () => {
-        httpSubscriptionResponseServer.on('request', (req) => {
+        httpSubscriptionResponseServer.on('request', (req, res) => {
             let sid = req.headers.sid;
             let handle = xmlResponseParser((err, data) => {
                 let emitter = subscriptions.get(sid);
@@ -24,7 +24,7 @@ portfinder.getPort(function (err, availablePort) {
                     emitter.emit('message', { sid: sid, body: data });
                 }
             });
-            handle(req);
+            handle(req, res);
         });
     });
 });

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
     "ip": "^1.0.1",
-    "portfinder": "^0.4.0",
-    "xml2js": "0.4.17"
+    "parsexmlresponse": "^0.0.3",
+    "portfinder": "^0.4.0"
   },
   "name": "node-upnp-subscription",
   "description": "Upnp subscription library for Node, handling subscription, renewal and expiry.",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
     "ip": "^1.0.1",
-    "parsexmlresponse": "^0.0.3",
-    "portfinder": "^0.4.0"
+    "portfinder": "^0.4.0",
+    "xml2js": "0.4.17"
   },
   "name": "node-upnp-subscription",
   "description": "Upnp subscription library for Node, handling subscription, renewal and expiry.",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "name": "node-upnp-subscription",
   "description": "Upnp subscription library for Node, handling subscription, renewal and expiry.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "index.js",
   "directories": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "ip": "^1.0.1",
-    "parsexmlresponse": "^0.0.3",
+    "parsexmlresponse": "^0.0.4",
     "portfinder": "^0.4.0"
   },
   "name": "node-upnp-subscription",


### PR DESCRIPTION
This PR speeds up the overall performance of the library by a large margin.

I was experiencing response times of approximately 3 seconds on average, between consecutive events. This PR reduces that wait time to approximately <10ms on average.

I believe the primary reason for the delay was with the `httpServer.on('request', ...` method, versus using the asynchronous `req.on('data', ...` method.

I also switched over to the `xml2js` library as that also seemed to speed up the overall response time a good bit.

My rough benchmarks are timed from when the UPnP device broadcasts the message (listening from another device), to the time that I am able to act on the `res.body` data sent to the `message` event listener.

Feel free to start a discussion on this, I was just trying to speed this up for my own use, and figured I would contribute back to help out everyone else.
