### PR TITLE
Hotfix: prevent http server loading on import

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,39 +7,48 @@ let util = require('util');
 let events = require('events');
 let xmlResponseParser = require('parsexmlresponse');
 
-var httpServerStarted;
-let httpServerPort;
+var httpServerEmitter = new events();
+var httpServerStarting = false;
+var httpServerStarted = false;
+var httpServerPort;
 let httpSubscriptionResponseServer;
 
 let subscriptions = new Map();
 
-let startHttpServer = function () {
-    httpServerStarted = true
-    portfinder.getPort(function (err, availablePort) {
-        httpSubscriptionResponseServer = http.createServer();
-        httpServerPort = availablePort;
-        httpSubscriptionResponseServer.listen(httpServerPort, () => {
-            console.log('listening on: ' + httpServerPort)
-            httpSubscriptionResponseServer.on('request', (req, res) => {
-                let sid = req.headers.sid;
-                let handle = xmlResponseParser((err, data) => {
-                    let emitter = subscriptions.get(sid);
-                    if (emitter) {
-                        emitter.emit('message', { sid: sid, body: data });
-                    }
+let ensureHttpServer = function (callback) {
+    if (httpServerStarting) {
+        httpServerEmitter.on('started', callback)
+    } else {
+        httpServerStarting = true
+        portfinder.getPort(function (err, availablePort) {
+            httpSubscriptionResponseServer = http.createServer();
+            httpServerPort = availablePort;
+            httpSubscriptionResponseServer.listen(httpServerPort, () => {
+                httpServerStarted = true;
+                httpServerEmitter.emit('started');
+                httpServerStarting = false;
+                httpSubscriptionResponseServer.on('request', (req, res) => {
+                    let sid = req.headers.sid;
+                    let handle = xmlResponseParser((err, data) => {
+                        let emitter = subscriptions.get(sid);
+                        if (emitter) {
+                            emitter.emit('message', { sid: sid, body: data });
+                        }
+                    });
+                    handle(req, res);
                 });
-                handle(req, res);
+                callback()
             });
         });
-    });
+    }
 };
 
 function Subscription(host, port, eventSub, requestedTimeoutSeconds) {
-    if (module.parent && !httpServerStarted) { startHttpServer() }
     let sid,
         resubscribeTimeout,
         emitter = this,
         timeoutSeconds = requestedTimeoutSeconds || 1800;
+
     function resubscribe() {
         if (sid) {
             var req = http.request({
@@ -59,7 +68,7 @@ function Subscription(host, port, eventSub, requestedTimeoutSeconds) {
             }).end();
         }
     }
-    function unsubscribe() {
+    this.unsubscribe = function unsubscribe() {
         clearTimeout(resubscribeTimeout);
         if (sid) {
             http.request({
@@ -79,38 +88,42 @@ function Subscription(host, port, eventSub, requestedTimeoutSeconds) {
             emitter.emit('error:unsubscribe', new Error('No SID for subscription'));
         }
         subscriptions.delete(sid);
-    }
-    http.request({
-        host: host,
-        port: port,
-        path: eventSub,
-        method: 'SUBSCRIBE',
-        headers: {
-            'CALLBACK': "<http://" + ip.address() + ':' + httpServerPort + ">",
-            'NT': 'upnp:event',
-            'TIMEOUT': 'Second-' + timeoutSeconds
-        }
-    }, function(res) {
-        emitter.emit('subscribed', { sid: res.headers.sid });
-        sid = res.headers.sid;
-        if (res.headers.timeout) {
-            let subscriptionTimeout = res.headers.timeout.match(/\d+/);
-            if (subscriptionTimeout) {
-                timeoutSeconds = subscriptionTimeout[0];
+    }.bind(this)
+
+    this.init = function init () {
+        http.request({
+            host: host,
+            port: port,
+            path: eventSub,
+            method: 'SUBSCRIBE',
+            headers: {
+                'CALLBACK': "<http://" + ip.address() + ':' + httpServerPort + ">",
+                'NT': 'upnp:event',
+                'TIMEOUT': 'Second-' + timeoutSeconds
             }
-        }
-        resubscribeTimeout = setTimeout(resubscribe, (timeoutSeconds-1) * 1000);
-        subscriptions.set(sid, emitter);
-    }).on('error', function(e) {
-        emitter.emit('error', e);
-        subscriptions.delete(sid);
-    }).end();
-    events.EventEmitter.call(this);
-    this.unsubscribe = unsubscribe;
+        }, function(res) {
+            emitter.emit('subscribed', { sid: res.headers.sid });
+            sid = res.headers.sid;
+            if (res.headers.timeout) {
+                let subscriptionTimeout = res.headers.timeout.match(/\d+/);
+                if (subscriptionTimeout) {
+                    timeoutSeconds = subscriptionTimeout[0];
+                }
+            }
+            resubscribeTimeout = setTimeout(resubscribe, (timeoutSeconds-1) * 1000);
+            subscriptions.set(sid, emitter);
+        }).on('error', function(e) {
+            emitter.emit('error', e);
+            subscriptions.delete(sid);
+        }).end();
+        events.EventEmitter.call(this);
+    }.bind(this)
+
+    if (!httpServerStarted) {
+        ensureHttpServer(this.init)
+    } else {
+        this.init()
+    }
 }
 util.inherits(Subscription, events.EventEmitter);
 module.exports = Subscription;
-
-if (!module.parent && !httpServerStarted) {
-    startHttpServer()
-}

--- a/index.js
+++ b/index.js
@@ -7,10 +7,10 @@ let util = require('util');
 let events = require('events');
 let xmlResponseParser = require('parsexmlresponse');
 
-var httpServerEmitter = new events();
-var httpServerStarting = false;
-var httpServerStarted = false;
-var httpServerPort;
+let httpServerEmitter = new events();
+let httpServerStarting = false;
+let httpServerStarted = false;
+let httpServerPort;
 let httpSubscriptionResponseServer;
 
 let subscriptions = new Map();

--- a/index.js
+++ b/index.js
@@ -5,28 +5,35 @@ let portfinder = require('portfinder');
 let ip = require('ip');
 let util = require('util');
 let events = require('events');
-let xmlResponseParser = require('parsexmlresponse');
+let xml = require('xml2js');
 
 let httpServerPort;
-let httpSubscriptionResponseServer;
 
 let subscriptions = new Map();
 
 portfinder.getPort(function (err, availablePort) {
-    httpSubscriptionResponseServer = http.createServer();
-    httpServerPort = availablePort;
-    httpSubscriptionResponseServer.listen(httpServerPort, () => {
-        httpSubscriptionResponseServer.on('request', (req) => {
-            let sid = req.headers.sid;
-            let handle = xmlResponseParser((err, data) => {
-                let emitter = subscriptions.get(sid);
-                if (emitter) {
-                    emitter.emit('message', { sid: sid, body: data });
-                }
-            });
-            handle(req);
-        });
-    });
+    httpServerPort = availablePort
+    http.createServer(function (req, res) {
+      var buffer = ''
+      req.on('data', function (d) {
+        buffer += d
+      })
+
+      req.on('end', function () {
+        req.body = buffer
+
+        let sid = req.headers.sid;
+
+        xml.parseString(req.body, (err, result) => {
+            let emitter = subscriptions.get(sid);
+            if (emitter) {
+                emitter.emit('message', { sid: sid, body: result });
+            }
+        })
+
+        res.end()
+      })
+    }).listen(httpServerPort)
 });
 
 function Subscription(host, port, eventSub, requestedTimeoutSeconds) {

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ portfinder.getPort(function (err, availablePort) {
     httpSubscriptionResponseServer = http.createServer();
     httpServerPort = availablePort;
     httpSubscriptionResponseServer.listen(httpServerPort, () => {
-        httpSubscriptionResponseServer.on('request', (req) => {
+        httpSubscriptionResponseServer.on('request', (req, res) => {
             let sid = req.headers.sid;
             let handle = xmlResponseParser((err, data) => {
                 let emitter = subscriptions.get(sid);
@@ -24,7 +24,7 @@ portfinder.getPort(function (err, availablePort) {
                     emitter.emit('message', { sid: sid, body: data });
                 }
             });
-            handle(req);
+            handle(req, res);
         });
     });
 });

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
     "ip": "^1.0.1",
-    "portfinder": "^0.4.0",
-    "xml2js": "0.4.17"
+    "parsexmlresponse": "^0.0.3",
+    "portfinder": "^0.4.0"
   },
   "name": "node-upnp-subscription",
   "description": "Upnp subscription library for Node, handling subscription, renewal and expiry.",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "name": "node-upnp-subscription",
   "description": "Upnp subscription library for Node, handling subscription, renewal and expiry.",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "index.js",
   "directories": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "main": "index.js",
   "directories": {},
   "devDependencies": {
+    "async": "^2.0.1",
     "chai": "^3.4.1",
     "mocha": "^2.3.4",
     "nock": "^3.1.1"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
     "ip": "^1.0.1",
-    "parsexmlresponse": "^0.0.3",
-    "portfinder": "^0.4.0"
+    "portfinder": "^0.4.0",
+    "xml2js": "0.4.17"
   },
   "name": "node-upnp-subscription",
   "description": "Upnp subscription library for Node, handling subscription, renewal and expiry.",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "name": "node-upnp-subscription",
   "description": "Upnp subscription library for Node, handling subscription, renewal and expiry.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "index.js",
   "directories": {},
   "devDependencies": {


### PR DESCRIPTION
This PR fixes a bug that I encountered, that will prevent a script from exiting on completion (e.g. gulp/grunt) if the module is imported (or is imported via a sub-module).

The script now checks to see if the program is being run by itself, and if so, immediately starts the server. If the module is imported, then it waits for the first `Subscription` instance to be created. Only one server will be started for all instances of `Subscription`.
